### PR TITLE
fix: remove exclamation mark from message export in index.js

### DIFF
--- a/.changeset/short-singers-reflect.md
+++ b/.changeset/short-singers-reflect.md
@@ -1,0 +1,5 @@
+---
+"@enchart-test/changesets-test": patch
+---
+
+fix: remove exclamation mark from message export in index.js

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  message: "Hi World!",
+  message: "Hi World",
 };


### PR DESCRIPTION
Fixes a bug where the `message` in `index.js` returns a message with an exclamation mark.