### PR TITLE
feat: add `message` property to `object` export

### DIFF
--- a/.changeset/khaki-files-complain.md
+++ b/.changeset/khaki-files-complain.md
@@ -1,0 +1,5 @@
+---
+"@enchart-test/changesets-test": minor
+---
+
+Adds `message` property to the `object` export. This property contains a second message.

--- a/index.js
+++ b/index.js
@@ -2,5 +2,6 @@ module.exports = {
   message: "Hi World",
   object: {
     number: 123,
+    message: "Second Message",
   },
 };


### PR DESCRIPTION
Adds `message` property to the `object` export. This property contains a second message.