### PR TITLE
fix: `object.number` being `123` instead of `456`

### DIFF
--- a/.changeset/itchy-badgers-burn.md
+++ b/.changeset/itchy-badgers-burn.md
@@ -1,0 +1,5 @@
+---
+"@enchart-test/changesets-test": patch
+---
+
+Fixes a bug where `object.number` is equal to `123` instead of the expected `456`

--- a/.changeset/itchy-badgers-burn.md
+++ b/.changeset/itchy-badgers-burn.md
@@ -2,4 +2,4 @@
 "@enchart-test/changesets-test": patch
 ---
 
-Fixes a bug where `object.number` is equal to `123` instead of the expected `456`
+Fixes a bug where `object.number` is equal to `123` instead of the expected `456`.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   message: "Hi World",
   object: {
-    number: 123,
+    number: 456,
     message: "Second Message",
   },
 };


### PR DESCRIPTION
Fixes a bug where `object.number` is equal to `123` instead of the expected `456`.